### PR TITLE
Add fuzzy tests using quickcheck

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ bench = true
 [features]
 default = []
 fpbkdf2 = ["fastpbkdf2"]
+fuzzy_tests = []
 
 [dependencies]
 rust-crypto = "^0.2"
@@ -25,3 +26,6 @@ rand = "^0.3"
 pwhash = "^0.1"
 regex = "0.1"
 fastpbkdf2 = { version = "0.1.0", optional = true }
+
+[dev-dependencies]
+quickcheck = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ rand = "^0.3"
 pwhash = "^0.1"
 regex = "0.1"
 fastpbkdf2 = { version = "0.1.0", optional = true }
+lazy_static = "0.2.1"
 
 [dev-dependencies]
 quickcheck = "0.3"

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 A Rust port of the password primitives used in [Django Project](https://www.djangoproject.com).
 
-Django's `django.contrib.auth.models.User` class has a few methods to deal with passwords, like `set_password()` and `check_password()`; **DjangoHashers** implements the primitive functions behind that methods. All Django's built-in hashers are supported.
+Django's `django.contrib.auth.models.User` class has a few methods to deal with passwords, like `set_password()` and `check_password()`; **DjangoHashers** implements the primitive functions behind those methods. All Django's built-in hashers are supported.
 
 This library was conceived for Django integration, but is not limited to it; you can use the password hash algorithm in any Rust project (or FFI integration), since its security model is already battle-tested.
 
-## Instalation
+## Installation
 
 Add the dependency to your `Cargo.toml`:
 
@@ -31,9 +31,9 @@ use djangohashers::{check_password, make_password, Algorithm};
 
 ## Fast PBKDF2 Version
 
-Unfortunately rust-crypto’s implementation of PBKDF2 is not properly optimized: it does not adheres to the loop inlines and buffering used in [modern implementations](https://jbp.io/2015/08/11/pbkdf2-performance-matters/). The package [fastpbkdf2](https://github.com/ctz/rust-fastpbkdf2) uses a C-binding of a [library](https://github.com/ctz/fastpbkdf2) that requires OpenSSL.
+Unfortunately rust-crypto’s implementation of PBKDF2 is not properly optimized: it does not adhere to the loop inlines and buffering used in [modern implementations](https://jbp.io/2015/08/11/pbkdf2-performance-matters/). The package [fastpbkdf2](https://github.com/ctz/rust-fastpbkdf2) uses a C-binding of a [library](https://github.com/ctz/fastpbkdf2) that requires OpenSSL.
 
-### Instalation
+### Installation
 
 Add the dependency to your `Cargo.toml` declaring the feature:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 
 extern crate rand;
 extern crate regex;
+#[macro_use] extern crate lazy_static;
 
 use rand::Rng;
 mod crypto_utils;
@@ -148,10 +149,13 @@ fn random_salt() -> String {
     rand::thread_rng().gen_ascii_chars().take(12).collect::<String>()
 }
 
+lazy_static! {
+    pub static ref VALID_SALT_RE: Regex = Regex::new(r"^[A-Za-z0-9]*$").unwrap();
+}
+
 /// Core function that generates all combinations of passwords:
 pub fn make_password_core(password: &str, salt: &str, algorithm: Algorithm, version: Version) -> String {
-    let valid_salt_re = Regex::new(r"^[A-Za-z0-9]*$").unwrap();
-    assert!(valid_salt_re.is_match(salt), "Salt can only contain letters and numbers.");
+    assert!(VALID_SALT_RE.is_match(salt), "Salt can only contain letters and numbers.");
     let hasher = get_hasher(&algorithm);
     hasher.encode(password, salt, iterations(&version, &algorithm))
 }

--- a/tests/fuzzy_tests.rs
+++ b/tests/fuzzy_tests.rs
@@ -8,11 +8,9 @@ extern crate regex;
 mod fuzzy_tests {
     use djangohashers::*;
     use quickcheck::TestResult;
-    use regex::Regex;
 
     fn check_algorithm(pwd: String, salt: String, algorithm: Algorithm) -> TestResult {
-        let valid_salt_re = Regex::new(r"^[A-Za-z0-9]*$").unwrap();
-        if !valid_salt_re.is_match(&salt) {
+        if !VALID_SALT_RE.is_match(&salt) {
             return TestResult::discard();
         }
 

--- a/tests/fuzzy_tests.rs
+++ b/tests/fuzzy_tests.rs
@@ -1,8 +1,5 @@
-#[macro_use]
-extern crate quickcheck;
-extern crate rand;
+#[macro_use] extern crate quickcheck;
 extern crate djangohashers;
-extern crate regex;
 
 #[cfg(feature = "fuzzy_tests")]
 mod fuzzy_tests {

--- a/tests/fuzzy_tests.rs
+++ b/tests/fuzzy_tests.rs
@@ -1,0 +1,75 @@
+#[macro_use]
+extern crate quickcheck;
+extern crate rand;
+extern crate djangohashers;
+extern crate regex;
+
+#[cfg(feature = "fuzzy_tests")]
+mod fuzzy_tests {
+    use djangohashers::*;
+    use quickcheck::TestResult;
+    use regex::Regex;
+
+    fn check_algorithm(pwd: String, salt: String, algorithm: Algorithm) -> TestResult {
+        let valid_salt_re = Regex::new(r"^[A-Za-z0-9]*$").unwrap();
+        if !valid_salt_re.is_match(&salt) {
+            return TestResult::discard();
+        }
+
+        TestResult::from_bool(check_password_tolerant(&pwd, &make_password_with_settings(&pwd, &salt, algorithm)))
+    }
+
+    quickcheck! {
+        fn test_fuzzy_pbkdf2(pwd: String, salt: String) -> TestResult {
+            check_algorithm(pwd, salt, Algorithm::PBKDF2)
+        }
+    }
+
+    quickcheck! {
+        fn test_fuzzy_pbkdf2sha1(pwd: String, salt: String) -> TestResult {
+            check_algorithm(pwd, salt, Algorithm::PBKDF2SHA1)
+        }
+    }
+
+    quickcheck! {
+        fn test_fuzzy_bcryptsha256(pwd: String, salt: String) -> TestResult {
+            check_algorithm(pwd, salt, Algorithm::BCryptSHA256)
+        }
+    }
+
+    //quickcheck! {
+    //    fn test_fuzzy_bcrypt(pwd: String, salt: String) -> TestResult {
+    //        check_algorithm(pwd, salt, Algorithm::BCrypt)
+    //    }
+    //}
+
+    quickcheck! {
+        fn test_fuzzy_sha1(pwd: String, salt: String) -> TestResult {
+            check_algorithm(pwd, salt, Algorithm::SHA1)
+        }
+    }
+
+    quickcheck! {
+        fn test_fuzzy_md5(pwd: String, salt: String) -> TestResult {
+            check_algorithm(pwd, salt, Algorithm::MD5)
+        }
+    }
+
+    quickcheck! {
+        fn test_fuzzy_unsaltedsha1(pwd: String, salt: String) -> TestResult {
+            check_algorithm(pwd, salt, Algorithm::UnsaltedSHA1)
+        }
+    }
+
+    quickcheck! {
+        fn test_fuzzy_unsaltedmd5(pwd: String, salt: String) -> TestResult {
+            check_algorithm(pwd, salt, Algorithm::UnsaltedMD5)
+        }
+    }
+
+    quickcheck! {
+        fn test_fuzzy_crypt(pwd: String, salt: String) -> TestResult {
+            check_algorithm(pwd, salt, Algorithm::Crypt)
+        }
+    }
+}

--- a/tests/fuzzy_tests.rs
+++ b/tests/fuzzy_tests.rs
@@ -32,11 +32,15 @@ mod fuzzy_tests {
         }
     }
 
-    //quickcheck! {
-    //    fn test_fuzzy_bcrypt(pwd: String, salt: String) -> TestResult {
-    //        check_algorithm(pwd, salt, Algorithm::BCrypt)
-    //    }
-    //}
+    quickcheck! {
+        fn test_fuzzy_bcrypt(pwd: String, salt: String) -> TestResult {
+            if pwd.len() >= 72 {
+                return TestResult::discard();
+            }
+
+            check_algorithm(pwd, salt, Algorithm::BCrypt)
+        }
+    }
 
     quickcheck! {
         fn test_fuzzy_sha1(pwd: String, salt: String) -> TestResult {


### PR DESCRIPTION
This uses Quickcheck to verify for each algorithm that passwords can be encoded and decoded. It will test various combinations of password/salt in order to identify flaws in the implementation.

These tests are rather slow to execute and are disabled by default. They are hidden behind feature `fuzzy-tests`. To include them in your tests run, execute the following command:
```
cargo test --release --features fuzzy-tests
```

New BCrypt fuzzy tests currently do not pass and were therefore left commented out.